### PR TITLE
POST_STATUS: handle post status changes

### DIFF
--- a/frontend/.idea/workspace.xml
+++ b/frontend/.idea/workspace.xml
@@ -5,13 +5,19 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3a06219a-0e59-490a-972e-c014166d5682" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/app/entities/tag.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/endpoint.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/endpoint.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/entities/post.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/entities/post.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/pages/posts/components/post_card.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/pages/posts/components/post_card.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/pages/posts/post_show.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/pages/posts/post_show.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/pages/posts/components/post_form.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/pages/posts/components/post_form.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/pages/posts/post_index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/pages/posts/post_index.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/repositories/post_repository.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/repositories/post_repository.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/services/dtos/responses/post_dto.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/services/dtos/responses/post_dto.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/services/post_service.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/services/post_service.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../instagram/src/main/java/main/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/../instagram/src/main/java/main/controller/PostController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../instagram/src/main/java/main/entity/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/../instagram/src/main/java/main/entity/Post.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../instagram/src/main/java/main/entity/PostStatus.java" beforeDir="false" afterPath="$PROJECT_DIR$/../instagram/src/main/java/main/entity/PostStatus.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/../instagram/src/main/java/main/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/../instagram/src/main/java/main/service/PostService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../instagram/src/main/java/main/service/dto/PostDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/../instagram/src/main/java/main/service/dto/PostDTO.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -24,7 +30,7 @@
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
     "Vitest.posts_service.test.ts.executor": "Run",
-    "git-widget-placeholder": "VOTE",
+    "git-widget-placeholder": "POST__STATUS",
     "node.js.selected.package.tslint": "(autodetect)",
     "npm.dev.executor": "Run",
     "ts.external.directory.path": "E:\\AN3\\SEM2\\ps_\\assignment\\frontend\\node_modules\\typescript\\lib"
@@ -34,6 +40,7 @@
     <servers />
   </component>
   <component name="VcsManagerConfiguration">
-    <option name="LAST_COMMIT_MESSAGE" value="" />
+    <MESSAGE value="merging main" />
+    <option name="LAST_COMMIT_MESSAGE" value="merging main" />
   </component>
 </project>

--- a/frontend/app/entities/post.ts
+++ b/frontend/app/entities/post.ts
@@ -15,11 +15,12 @@ export interface Post {
 export interface PostAttributes {
     title: string;
     text: string;
-    status: string;
+    status: "NEW" | "ACTIVE" | "FIRST_REACTION" | "OUTDATED";
     imagePath: string;
     createdAt: string;
     updatedAt: string;
     tags: string[];
+    is_commentable: boolean;
 }
 
 export interface PostRelationships {

--- a/frontend/app/pages/posts/components/post_card.tsx
+++ b/frontend/app/pages/posts/components/post_card.tsx
@@ -7,6 +7,8 @@ import {
   faPen,
   faStar,
   faTrash,
+  faLock,
+  faLockOpen,
 } from "@fortawesome/free-solid-svg-icons";
 import { DateFormatter } from "~/utils/date_formatter";
 import React, { useState, useEffect } from "react";
@@ -41,6 +43,11 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
   const voteService = new VoteService();
 
   useEffect(() => {
+    new PostsService().find(post.id.toString()).then((freshPost) => {
+      setCurrentPost(freshPost);
+    });
+  }, [post.id]);
+  useEffect(() => {
     const fetchPostData = async () => {
       try {
         const freshPost = await new PostsService().find(post.id.toString());
@@ -65,6 +72,25 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
 
     fetchPostData();
   }, [post.id]);
+
+  function deletePost(event: React.MouseEvent<HTMLSpanElement>, id: number) {
+    event.preventDefault();
+
+    new PostsService()
+      .delete(id.toString())
+      .then(() => {
+        setType(AlertDestructiveEnum.success);
+        setMessage("Post deleted successfully.");
+      })
+      .catch((err) => {
+        setType(AlertDestructiveEnum.error);
+        setMessage(
+          err instanceof Error
+            ? err.message
+            : "An unknown error occurred. Hold tight!"
+        );
+      });
+  }
 
   async function handleVote(type: VoteType) {
     if (isVoting) return;
@@ -107,27 +133,35 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
     }
   }
 
-  function deletePost(event: React.MouseEvent<HTMLSpanElement>, id: number) {
-    event.preventDefault();
-
-        new PostsService().delete(id.toString()).then(() => {
-            setType(AlertDestructiveEnum.success);
-            setMessage("Post deleted successfully.");
-        }).catch((err) => {
-            setType(AlertDestructiveEnum.error);
-            setMessage(err instanceof Error ? err.message : "An unknown error occurred. Hold tight!")
-        });
+  async function handleToggleComments() {
+    try {
+      const updatedPost = await new PostsService().toggleCommentability(
+        currentPost.id.toString()
+      );
+      setCurrentPost(updatedPost);
+      setType(AlertDestructiveEnum.success);
+      setMessage(
+        updatedPost.attributes.status === "OUTDATED"
+          ? "Comments disabled successfully"
+          : "Comments enabled successfully"
+      );
+    } catch (error) {
+      setType(AlertDestructiveEnum.error);
+      setMessage(
+        error instanceof Error ? error.message : "Failed to toggle comments"
+      );
     }
+  }
 
-    function canEditPost(post: Post): boolean {
-        const loggedUser = sessionStorage.getItem("username");
-        const role = sessionStorage.getItem("role");
-        const authorUsername = post.relationships?.author?.attributes?.username;
+  function canEditPost(post: Post): boolean {
+    const loggedUser = sessionStorage.getItem("username");
+    const role = sessionStorage.getItem("role");
+    const authorUsername = post.relationships?.author?.attributes?.username;
 
-        if (role == "MODERATOR") return true;
+    if (role == "MODERATOR") return true;
 
-        return authorUsername === loggedUser;
-    }
+    return authorUsername === loggedUser;
+  }
 
   return (
     <div className="bg-gradient-to-br from-[#e74c3c] via-[#641e16] to-[#ec7063] p-[2px] rounded-lg">
@@ -143,6 +177,26 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
                 {canEditPost(currentPost) && (
                   <div className="flex items-center justify-end">
                     <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        handleToggleComments();
+                      }}
+                      className="text-orange-600 mr-4 text-sm cursor-pointer hover:underline"
+                    >
+                      {currentPost.attributes.status === "OUTDATED"
+                        ? "Enable comments"
+                        : "Disable comments"}
+                      <FontAwesomeIcon
+                        icon={
+                          currentPost.attributes.status === "OUTDATED"
+                            ? faLockOpen
+                            : faLock
+                        }
+                        className="ml-2"
+                      />
+                    </button>
+                    <button
                       onClick={() =>
                         (window.location.href = `/posts/${currentPost.id.toString()}/edit`)
                       }
@@ -152,7 +206,7 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
                       <FontAwesomeIcon icon={faPen} className="ml-2" />
                     </button>
                     <span
-                      className="text-red-700 text-sm cursor-pointer hover:underline"
+                      className="text-orange-600 text-sm cursor-pointer hover:underline"
                       onClick={(e) => deletePost(e, currentPost.id)}
                     >
                       Delete
@@ -173,7 +227,16 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
               </span>
               <span className="text-gray-400">
                 {currentPost.relationships?.author?.attributes.username} ·{" "}
-                {DateFormatter.formatDate(post.attributes.createdAt)} · DRAFT
+                {DateFormatter.formatDate(post.attributes.createdAt)} ·{" "}
+                {currentPost.attributes.status === "NEW"
+                  ? "New"
+                  : currentPost.attributes.status === "ACTIVE"
+                  ? "Active"
+                  : currentPost.attributes.status === "FIRST_REACTION"
+                  ? "First Reaction"
+                  : currentPost.attributes.status === "OUTDATED"
+                  ? "Outdated"
+                  : currentPost.attributes.status}
               </span>
             </div>
           </div>
@@ -202,18 +265,42 @@ export function PostCard({ post, setMessage, setType }: PostCardProps) {
               {voteCount.count}
             </span>
           </div>
-          <div className="group flex items-center space-x-2 cursor-pointer transition-all duration-500">
+          <button
+            className={`group flex items-center space-x-2 ${
+              currentPost.attributes.status !== "OUTDATED"
+                ? "cursor-pointer"
+                : "cursor-not-allowed opacity-50"
+            } transition-all duration-500`}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (currentPost.attributes.status !== "OUTDATED") {
+                window.location.href = `/posts/${currentPost.id}`;
+              }
+            }}
+            disabled={currentPost.attributes.status === "OUTDATED"}
+          >
             <div className="relative">
               <div className="absolute w-6 h-6 rounded-full group-hover:scale-100 bg-[#3498db] transition-all duration-200 opacity-20 scale-0 -translate-x-1/5 -translate-y-1/16" />
               <FontAwesomeIcon
                 icon={faComment}
-                className="text-gray-400 group-hover:text-[#3498db] relative transition-all duration-300"
+                className={`text-gray-400 ${
+                  currentPost.attributes.status !== "OUTDATED"
+                    ? "group-hover:text-[#3498db]"
+                    : ""
+                } relative transition-all duration-300`}
               />
             </div>
-            <span className="text-gray-400 group-hover:text-[#3498db] transition-all duration-300">
+            <span
+              className={`text-gray-400 ${
+                currentPost.attributes.status !== "OUTDATED"
+                  ? "group-hover:text-[#3498db]"
+                  : ""
+              } transition-all duration-300`}
+            >
               {currentPost.relationships?.comments?.length ?? "0"}
             </span>
-          </div>
+          </button>
           <div
             className="group flex items-center space-x-2 cursor-pointer transition-all duration-500"
             onClick={(e) => {

--- a/frontend/app/pages/posts/components/post_form.tsx
+++ b/frontend/app/pages/posts/components/post_form.tsx
@@ -54,17 +54,28 @@ export function PostForm({ setMessage, setType, submitButtonText, titlePlacehold
         e.preventDefault();
         if (isSubmitting) return;
 
-        setIsSubmitting(true);
-        try {
-          validateData();
-          const tagArray = tags
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0)
-            .map((tag) => {
-              const cleanTag = tag.replace(/^#+/, "").trim();
-              return `#${cleanTag}`;
-            });
+    setIsSubmitting(true);
+    try {
+      validateData();
+
+      // If this is a comment, check if the parent post allows comments
+      if (postParentId) {
+        const parentPost = await new PostsService().find(
+          postParentId.toString()
+        );
+        if (parentPost.attributes.status === "OUTDATED") {
+          throw new Error("Comments are disabled for this post");
+        }
+      }
+
+      const tagArray = tags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0)
+        .map((tag) => {
+          const cleanTag = tag.replace(/^#+/, "").trim();
+          return `#${cleanTag}`;
+        });
 
           await new PostsService().create(
             postTitle,

--- a/frontend/app/pages/posts/post_index.tsx
+++ b/frontend/app/pages/posts/post_index.tsx
@@ -26,8 +26,10 @@ export function PostIndex({ posts }: PostIndexProps) {
     const users = new Set<string>();
 
     posts.forEach((post) => {
-      post.attributes.tags?.forEach((tag) => tags.add(tag));
-      if (post.relationships.author) {
+      if (post.attributes?.tags) {
+        post.attributes.tags.forEach((tag) => tags.add(tag));
+      }
+      if (post.relationships?.author?.attributes?.username) {
         users.add(post.relationships.author.attributes.username);
       }
     });

--- a/frontend/app/repositories/post_repository.ts
+++ b/frontend/app/repositories/post_repository.ts
@@ -60,6 +60,21 @@ export class PostRepository {
 
         const response = await api.put<Post>(ENDPOINTS.POSTS + `/${data.id}`, formData);
 
-        return response.data;
+     return response.data;
+  }
+
+  async toggleCommentability(id: string): Promise<Post> {
+    try {
+      const response = await api.put<Post>(
+        ENDPOINTS.POSTS + `/${id}/toggle-comments`
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error toggling commentability:", error);
+      if (error instanceof Error) {
+        throw new Error(`Failed to toggle commentability: ${error.message}`);
+      }
+      throw new Error("Failed to toggle commentability: Unknown error");
     }
+  }
 }

--- a/frontend/app/services/dtos/responses/post_dto.ts
+++ b/frontend/app/services/dtos/responses/post_dto.ts
@@ -3,8 +3,14 @@ import type {RelationshipDTO} from "~/services/dtos/relationship_dto";
 export interface PostDTO {
     type: 'posts',
     attributes: {
-        title: string,
-        text: string,
+        title: string;
+        text: string;
+        status: string;
+        imagePath: string | null;
+        createdAt: string;
+        updatedAt: string;
+        tags: string[];
+        is_commentable: boolean;
     },
     relationships: {
         author: {

--- a/frontend/app/services/post_service.ts
+++ b/frontend/app/services/post_service.ts
@@ -60,4 +60,7 @@ export class PostsService {
         return this.postsRepository.update(newPost);
     }
 
+  async toggleCommentability(id: string): Promise<Post> {
+    return this.postsRepository.toggleCommentability(id);
+  }
 }

--- a/instagram/src/main/java/main/controller/PostController.java
+++ b/instagram/src/main/java/main/controller/PostController.java
@@ -86,6 +86,30 @@ public class PostController {
     }
   }
 
+  @PutMapping("/{id}/toggle-comments")
+  @RequireAuthentication
+  public ResponseEntity<PostDTO> toggleCommentability(@PathVariable Long id, HttpSession session) {
+    try {
+      return ResponseEntity.ok(postService.toggleCommentability(id, session));
+    } catch (RuntimeException e) {
+      String message = e.getMessage();
+      if (message == null) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+      }
+
+      if (message.contains("Not authenticated")) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      }
+      if (message.contains("Not authorized")) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+      }
+      if (message.contains("Post not found")) {
+        return ResponseEntity.notFound().build();
+      }
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
   @DeleteMapping("/{id}")
   @RequireAuthentication
   public ResponseEntity<Void> delete(@PathVariable Long id, HttpSession session) {

--- a/instagram/src/main/java/main/entity/Post.java
+++ b/instagram/src/main/java/main/entity/Post.java
@@ -63,7 +63,7 @@ public class Post {
   protected void onCreate() {
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
-    this.status = PostStatus.DRAFT;
+    this.status = PostStatus.NEW;
     this.is_commentable = true;
   }
 

--- a/instagram/src/main/java/main/entity/PostStatus.java
+++ b/instagram/src/main/java/main/entity/PostStatus.java
@@ -1,7 +1,8 @@
 package main.entity;
 
 public enum PostStatus {
-  DRAFT,
-  PUBLISHED,
-  ARCHIVED;
+  NEW,
+  ACTIVE,
+  FIRST_REACTION,
+  OUTDATED
 }

--- a/instagram/src/main/java/main/service/PostService.java
+++ b/instagram/src/main/java/main/service/PostService.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import main.entity.Post;
+import main.entity.PostStatus;
 import main.entity.User;
 import main.entity.UserType;
 import main.repository.IPostRepository;
-import main.repository.ITagRepository;
 import main.service.dto.PostCreateRequest;
 import main.service.dto.PostDTO;
 import main.service.dto.PostUpdateRequest;
@@ -127,4 +127,33 @@ public class PostService {
     // Clean up any unused tags
     tagService.deleteUnusedTags();
   }
+
+    @Transactional
+    public PostDTO toggleCommentability(Long id, HttpSession session) {
+        User authenticatedUser = authenticationService.getAuthenticatedUser(session);
+        Post post = postRepository
+                .findById(id)
+                .orElseThrow(() -> new RuntimeException("Post not found with ID: " + id));
+
+        if (!post.getAuthor().getId().equals(authenticatedUser.getId())
+                && !authenticatedUser.getRole().equals(UserType.MODERATOR)) {
+            throw new RuntimeException("Not authorized to modify this post");
+        }
+
+        post.set_commentable(!post.is_commentable());
+
+        if (!post.is_commentable()) {
+            post.setStatus(PostStatus.OUTDATED);
+        } else {
+            if (post.getComments().isEmpty()) {
+                post.setStatus(PostStatus.NEW);
+            } else if (post.getComments().size() == 1) {
+                post.setStatus(PostStatus.FIRST_REACTION);
+            } else {
+                post.setStatus(PostStatus.ACTIVE);
+            }
+        }
+
+        return PostDTO.withRelationships(postRepository.save(post));
+    }
 }

--- a/instagram/src/main/java/main/service/dto/PostDTO.java
+++ b/instagram/src/main/java/main/service/dto/PostDTO.java
@@ -37,7 +37,8 @@ public class PostDTO {
                 : new LocalImageProvider().getUrl(post.getImagePath()),
             post.getCreatedAt(),
             post.getUpdatedAt(),
-            post.getTags().stream().map(tag -> tag.getTitle()).collect(Collectors.toList()));
+            post.getTags().stream().map(tag -> tag.getTitle()).collect(Collectors.toList()),
+            post.is_commentable());
     this.relationships =
         includeRelationships
             ? new PostRelationships(post.getAuthor(), post.getParent(), post.getComments())
@@ -64,6 +65,7 @@ public class PostDTO {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<String> tags;
+    private boolean is_commentable;
   }
 
   @Data


### PR DESCRIPTION
# Post status

Implemented the status changes based on interactions with the post.

## Technical Details
- Comments are now only disabled when a post has "OUTDATED" status
- Posts with "ACTIVE", "NEW", or "FIRST_REACTION" status will have comments enabled
- The UI now correctly reflects this relationship:
  - Comment button is only disabled for "OUTDATED" posts
  - Comment form validation checks post status instead of `is_commentable` flag
  - Status display shows only the post status without redundant comment state